### PR TITLE
Update doubtlab version to match PyPI (v0.1.2)

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,6 +6,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-zip_keys:
-- - cdt_name
-  - docker_image

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "doubtlab" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.2" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e2065c916820ac6008883032594c14a0a660862cb012f3fac152a97f4c3c64b4
+  sha256: f745b6d9866c767af9773c3a08efafb6d0e13cbe58a3e3e8bed094a480127065
 
 build:
   number: 0
@@ -16,11 +16,12 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
+  {% set pyver = ">=3.7,<4.0" %}
   host:
     - pip
-    - python >=3.6
+    - python {{ pyver }}
   run:
-    - python >=3.6
+    - python {{ pyver }}
     - cleanlab >=1.0
     - pandas >=1.3.3    
     - scikit-learn >=1.0.0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged). `NA`
* [x] Reset the build number to `0` (if the version changed) `v0.1.1 ---> v0.1.2`
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged. `Comes from PyPI`.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
